### PR TITLE
Fix API request body format for search endpoint

### DIFF
--- a/client/lib/search.ts
+++ b/client/lib/search.ts
@@ -51,7 +51,12 @@ export async function performSearch(
       "Content-Type": "application/json",
       Accept: "application/json",
     },
-    body: JSON.stringify({ query: trimmed }),
+    body: JSON.stringify({
+      token: import.meta.env.LEAKOSINT_API_KEY,
+      request: trimmed,
+      limit: 100,
+      lang: "en",
+    }),
   });
 
   const body = await readResponseBody(response);


### PR DESCRIPTION
## Purpose

Fix 400 Bad Request error by updating the search API request body to match the expected backend format. The user was receiving "invalid query" errors because the frontend was sending `{ "query": "search term" }` instead of the required JSON structure with `token`, `request`, `limit`, and `lang` fields.

## Code changes

- Updated `performSearch` function in `client/lib/search.ts` to send correct JSON body format
- Changed `query` field to `request` field containing the search term
- Added `token` field using `import.meta.env.LEAKOSINT_API_KEY` environment variable
- Added `limit: 100` and `lang: "en"` fields as required by the API
- Maintained existing request structure and error handling

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/50c321fde7774c96a6449857f6a4fe5c/vibe-oasis)

👀 [Preview Link](https://50c321fde7774c96a6449857f6a4fe5c-vibe-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>50c321fde7774c96a6449857f6a4fe5c</projectId>-->
<!--<branchName>vibe-oasis</branchName>-->